### PR TITLE
Export functions via CCALL and add wasm.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 bin/cidscropt
 todo.txt
 *.res
+obj/*.bc

--- a/src/include_ccall.h
+++ b/src/include_ccall.h
@@ -1,0 +1,21 @@
+#ifndef INCLUDE_CCALL_H
+#define INCLUDE_CCALL_H
+
+#ifdef __cplusplus
+	#define EXTERNC extern "C"
+#else
+	#define EXTERNC extern
+#endif
+
+#ifdef __EMSCRIPTEN__
+	#include <emscripten.h>
+	#define CCALL EXTERNC EMSCRIPTEN_KEEPALIVE
+#else
+	#if defined(_MSC_VER)
+	#	define CCALL EXTERNC __declspec(dllexport)
+	#else
+	#	define CCALL EXTERNC __attribute__((visibility("default")))
+	#endif
+#endif
+
+#endif

--- a/src/standalone.c
+++ b/src/standalone.c
@@ -8,6 +8,8 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
+#include "include_ccall.h"
+
 /* used this to test C SDL ffi */
 //#include <SDL.h>
 //#undef main
@@ -43,7 +45,7 @@ void one_iter()
 
 #ifdef __EMSCRIPTEN__
 
-void script_command(const char *cmd)
+CCALL void script_command(const char *cmd)
 {
 	emscripten_cancel_main_loop();
 	if (gvm)
@@ -53,7 +55,7 @@ void script_command(const char *cmd)
 	}
 }
 
-void run_script(const char *script)
+CCALL void run_script(const char *script)
 {
 	srand(time(0));
 	signal(SIGINT, signal_int);

--- a/wasm.bat
+++ b/wasm.bat
@@ -1,0 +1,20 @@
+if not exist "obj" mkdir obj
+if not exist "bin" mkdir bin
+
+echo "Compile sources..."
+
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/compiler.c -o obj/compiler.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/scr_defaultlib.c -o obj/scr_defaultlib.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/variable.c -o obj/variable.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/vm.c -o obj/vm.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/cvector.c -o obj/cvector.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/common.c -o obj/common.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/standalone.c -o obj/standalone.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/asm.c -o obj/asm.bc
+call emcc -w -Wall -m32 -std=gnu99 -DCIDSCROPT_STANDALONE -c src/resolve_exports.c -o obj/resolve_exports.bc
+
+echo "Link objects..."
+
+call emcc obj/compiler.bc obj/scr_defaultlib.bc obj/variable.bc obj/vm.bc obj/cvector.bc obj/common.bc obj/standalone.bc obj/asm.bc obj/resolve_exports.bc -o "bin/cidscropt.html" -ldl -lm -s EXTRA_EXPORTED_RUNTIME_METHODS="["ccall", "cwrap"]" -s ALLOW_MEMORY_GROWTH=1
+
+echo "Done."

--- a/wasm.sh
+++ b/wasm.sh
@@ -16,5 +16,5 @@ $cc -c resolve_exports.c -o obj/resolve_exports.bc
 echo "Made all bc files."
 
 obj="$(ls obj/*.bc)"
-$cc $obj -o "../bin/cidscropt.html" -ldl -lm -s EXPORTED_FUNCTIONS='["_main", "_run_script", "_script_command"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
+$cc $obj -o "../bin/cidscropt.html" -ldl -lm -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 echo "Done."


### PR DESCRIPTION
Just wasm.bat for Windows and making it easier to export all kinds of functions.

I would like to see every `vm_*` function exported later, to write a JavaScript wrapper, like:

```js
var vm = new VM();
vm.execThread("main");
console.log("VM Pointer:", vm.ptr);
```